### PR TITLE
Feature/comment basedhelp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gem 'rubocop', require: false, group: :test
 gem 'simplecov', require: false, group: :test
 gem 'test-unit', require: false, group: :test
 
+gem 'method_source'
 gem 'rake'

--- a/lib/cmd.rb
+++ b/lib/cmd.rb
@@ -1,4 +1,5 @@
 require 'readline'
+require 'method_source'
 
 # A simple command shell implementation that is inspired
 # from Python's +cmd.py+.
@@ -86,30 +87,52 @@ Type `help` for a list of available commands.', add_hist = true)
   # * +do_foo+ defines a command method for the command named +foo+
   # * +help_foo+ defines a help print command method for the command named +foo+
   #
-  # Note: if a +do_<command_name>+ method returns true it will terminate
+  # Note: If no +help_foo+ help print command method is defined,
+  # the documentation comments above the +do_foo+ command method will
+  # be used as a help message. If no such documentation comment
+  # exists for the +do_foo+ command method, a message stating that
+  # no help is available for the command +foo+ will be displayed.
+  #
+  # Note: If a +do_<command_name>+ method returns +true+ it will terminate
   # the +cmd_loop+.
 
-  def help_exit(input)
-    puts('Exit the command shell')
+  def help_help(input)
+    puts('Print the available commands within this shell.')
+    puts('Use `help <command name>` to get help on a specific command')
   end
 
-  # Exit the +cmd_loop+ by returning +true+.
+  def do_help(input)
+    if input == 'help' # basic +help+ command
+      puts('Use `help <command_name>` to get help on a specific command')
+      puts('Below is a list of available commands:')
+      method_commands = self.class.instance_methods(false).select { |s| s.to_s.start_with?('do_') }
+      method_commands.each do |method_symbol|
+        puts(method_symbol.to_s[3..-1])
+      end
+    else # advanced +help <command_name>+ command
+      target_command = input[5..-1]
+      if !(target_command_help_method = get_command_help_method_symbol(target_command)).nil?
+        send(target_command_help_method, input)
+      elsif !(target_command_method_help_comment = get_command_method_help_comment(target_command)).nil?
+        puts(target_command_method_help_comment)
+      else
+        puts('No help exists for command: ' + target_command)
+      end
+    end
+    false
+  end
+
+  # Exit the command shell.
   def do_exit(input)
     true
   end
 
-  def help_history(input)
-    puts('Print the history of past issued commands')
-  end
-
+  # Print the history of past issued commands.
   def do_history(input)
     puts(Readline::HISTORY.to_a)
   end
 
-  def help_cd(input)
-    puts('Change directory to the path specified')
-  end
-
+  # Change directory to the path specified.
   def do_cd(input)
     if (input != '') && (input.split('cd ')[0] == '')
       Dir.chdir(input.split('cd ')[1])
@@ -120,47 +143,42 @@ Type `help` for a list of available commands.', add_hist = true)
     false
   end
 
-  def help_help(input)
-    puts('Print the available commands within this shell.')
-    puts('Use `help <command name>` to get help on a specific command')
-  end
-
-  def do_help(input)
-    if input == 'help' # basic +help+ command
-      puts('Use `help <command name>` to get help on a specific command')
-      puts('Below is a list of available commands:')
-      method_commands = self.class.instance_methods(false).select { |s| s.to_s.start_with?('do_') }
-      method_commands.each do |method_symbol|
-        puts(method_symbol.to_s[3..-1])
-      end
-    else # advanced +help <command_name>+ command
-      target_command = input[5..-1]
-      if !(target_command_help_method = get_command_help_method_symbol(target_command)).nil?
-        send(target_command_help_method, input)
-      else
-        puts('No help exists for command: ' + target_command)
-      end
-    end
-    false
-  end
-
   ######
   # Dynamic +do_<command_name>+ and +help_<command_name>+ utilities
   ######
 
-  # Given a command name obtain the symbol representing its
-  # corresponding +do_<command_name>+ method.
-  def get_command_method_symbol(input)
-    return if input.nil?
+  # Given a +command_name+ obtain the symbol representing its
+  # corresponding +do_<command_name>+ command method.
+  def get_command_method_symbol(command_name)
+    return if command_name.nil?
 
-    self.class.instance_methods.select { |s| s.to_s.eql?('do_' + input) }[0]
+    self.class.instance_methods.select { |s| s.to_s.eql?('do_' + command_name) }[0]
   end
 
-  # Given a command name obtain the symbol representing its
-  # corresponding +help_<command_name>+ method.
-  def get_command_help_method_symbol(input)
-    return if input.nil?
+  # Given a +command_name+ obtain the symbol representing its
+  # corresponding +help_<command_name>+ help print command method.
+  def get_command_help_method_symbol(command_name)
+    return if command_name.nil?
 
-    self.class.instance_methods.select { |s| s.to_s.eql?('help_' + input) }[0]
+    self.class.instance_methods.select { |s| s.to_s.eql?('help_' + command_name) }[0]
+  end
+
+  # Given a +command_name+ obtain the documentation comments
+  # corresponding to +do_<command_name>+ command method.
+  def get_command_method_help_comment(command_name)
+    return if command_name.nil?
+    return if (command_symbol = get_command_method_symbol(command_name)).nil?
+
+    raw_comment = self.class.instance_method(command_symbol).comment
+    raw_comment = clean_help_comment(raw_comment)
+    return nil if raw_comment == ''
+
+    raw_comment
+  end
+
+  # Clean a command method comment string to be more console readable.
+  def clean_help_comment(raw_comment)
+    raw_comment.gsub!(/^# /, '')
+    raw_comment.strip
   end
 end


### PR DESCRIPTION
Allowing `do_<command_name>` command method documentation comments to generate a default `help <command_name>` message.