### PR TITLE
Feature/basic shell

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'simplecov', require: false, group: :test
 gem 'test-unit', require: false, group: :test
 
 gem 'method_source'
+gem 'sys-proctable'
 gem 'rake'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'simplecov', require: false, group: :test
 gem 'test-unit', require: false, group: :test
 
 gem 'method_source'
-gem 'sys-proctable'
 gem 'rake'
+gem 'sys-proctable'
 
 gemspec

--- a/assignment2_main_basic_shell.rb
+++ b/assignment2_main_basic_shell.rb
@@ -1,0 +1,16 @@
+# Run a Ruby built basic shell.
+#
+# This Library was made by:
+#
+# Group 4:
+#   Nathan Klapstein (1449872)
+#   Tony Qian (1396109)
+#   Thomas Lorincz (1461567)
+#   Zach Drever (1446384)
+#
+
+require 'cmd'
+require 'basic_shell'
+
+shell = BasicShell.new
+shell.cmd_loop

--- a/assignment2_main_basic_shell.rb
+++ b/assignment2_main_basic_shell.rb
@@ -9,7 +9,6 @@
 #   Zach Drever (1446384)
 #
 
-require 'cmd'
 require 'basic_shell'
 
 shell = BasicShell.new

--- a/lib/basic_shell.rb
+++ b/lib/basic_shell.rb
@@ -34,10 +34,12 @@ Type `help` for a list of available commands.')
     end
   end
 
-  # Usage: cd DIRECTORY
+  # Usage: cd [DIRECTORY]
   #
   # Change the current working DIRECTORY.
   def do_cd(arg)
+    return false if arg == ''
+
     Dir.chdir(arg)
     # TODO: error handling (permission/non-such)
     false

--- a/lib/basic_shell.rb
+++ b/lib/basic_shell.rb
@@ -137,11 +137,14 @@ Type `help` for a list of available commands.')
     file.close
   end
 
+  # Usage: fork COMMAND
+  #
+  # Fork and run the raw system COMMAND as a detached process.
   def do_fork(arg)
     r, w = IO.pipe
     pid = Process.spawn(arg, out: w)
     Process.detach pid
-    puts 'spawned process under pid: '+ pid.to_s
+    puts 'spawned process under pid: ' + pid.to_s
     w.close
     r.close
     false
@@ -152,7 +155,7 @@ Type `help` for a list of available commands.')
   # Send a system specific SIGNAL to the process(es) specified by the PID(s)
   def do_kill(arg)
     signal = arg.split(' ')[0]
-    pids = arg[signal.length+1..-1].split(' ')
+    pids = arg[signal.length + 1..-1].split(' ')
     pids.each do |pid|
       Process.kill(signal, pid)
       # TODO: error handling (non-such-signal/non-such-pid)

--- a/lib/basic_shell.rb
+++ b/lib/basic_shell.rb
@@ -13,11 +13,15 @@ Type `help` for a list of available commands.')
     init_line_reader
   end
 
+  # Usage: pwd
+  #
   # Print the current working DIRECTORY.
   def do_pwd(arg)
     puts Dir.pwd
   end
 
+  # Usage: ls [DIRECTORY]
+  #
   # List the filenames within a DIRECTORY.
   #
   # If no DIRECTORY is specified the current working DIRECTORY will be listed.
@@ -30,6 +34,8 @@ Type `help` for a list of available commands.')
     end
   end
 
+  # Usage: cd DIRECTORY
+  #
   # Change the current working DIRECTORY.
   def do_cd(arg)
     Dir.chdir(arg)
@@ -37,18 +43,24 @@ Type `help` for a list of available commands.')
     false
   end
 
+  # Usage: mkdir [DIRECTORIES]...
+  #
   # Create one or more DIRECTORIES.
   def do_mkdir(arg)
     FileUtils.mkdir arg.split(' ')
     false
   end
 
+  # Usage: rmdir [DIRECTORIES]...
+  #
   # Removes one or more DIRECTORIES.
   def do_rmdir(arg)
     FileUtils.rmdir arg.split(' ')
     false
   end
 
+  # Usage: rm [FILE]...
+  #
   # Remove one or more FILE(s).
   def do_rm(arg)
     FileUtils.rm arg.split(' ')
@@ -56,7 +68,9 @@ Type `help` for a list of available commands.')
     false
   end
 
-  # Move a FILE to the specified path.
+  # Usage: mv SOURCE DEST
+  #
+  # Move a SOURCE file to the specified DEST (destination) path.
   def do_mv(arg)
     args = arg.split(' ')
     FileUtils.mv args[0], args[1]
@@ -64,7 +78,9 @@ Type `help` for a list of available commands.')
     false
   end
 
-  # Copy a FILE to the specified path.
+  # Usage: SOURCE DEST
+
+  # Copy a SOURCE file to the specified DEST (destination) path.
   def do_cp(arg)
     args = arg.split(' ')
     FileUtils.cp args[0], args[1]
@@ -72,27 +88,42 @@ Type `help` for a list of available commands.')
     false
   end
 
+  # Usage: cat [FILE]...
+  #
   # Concatenate FILE(s) to standard output.
   def do_cat(arg)
     args = arg.split(' ')
-    args.each do |file|
-      f = File.open(file)
+    args.each do |filename|
+      f = File.open(filename)
       f.readlines.each(&method(:puts))
       f.close
     end
     false
   end
 
+  # Usage: touch [FILE]...
+  #
   # Update the access and modification times of each FILE to the current time.
   #
   # A FILE argument that does not exist is created empty.
   def do_touch(arg)
     args = arg.split(' ')
-    args.each do |file|
-      File.open(file, mode = 'w').close # rubocop:disable Lint/UselessAssignment:
+    args.each do |filename|
+      File.open(filename, mode = 'w').close # rubocop:disable Lint/UselessAssignment:
     end
     false
   end
 
-  # TODO: need some method to write to files (maybe implement the > operator?)
+  # Usage: write FILE CONTENT
+  #
+  # Write CONTENT to the given FILE.
+  #
+  # A FILE argument that does not exist is created and written with CONTENT.
+  def do_write(arg)
+    filename = arg.split(' ')[0]
+    content = arg[filename.length + 1..-1]
+    f = File.open(filename, mode = 'w')
+    f.syswrite(content)
+    f.close
+  end
 end

--- a/lib/basic_shell.rb
+++ b/lib/basic_shell.rb
@@ -94,9 +94,9 @@ Type `help` for a list of available commands.')
   def do_cat(arg)
     args = arg.split(' ')
     args.each do |filename|
-      f = File.open(filename)
-      f.readlines.each(&method(:puts))
-      f.close
+      file = File.open(filename)
+      file.readlines.each(&method(:puts))
+      file.close
     end
     false
   end
@@ -109,7 +109,8 @@ Type `help` for a list of available commands.')
   def do_touch(arg)
     args = arg.split(' ')
     args.each do |filename|
-      File.open(filename, mode = 'w').close # rubocop:disable Lint/UselessAssignment:
+      file = File.open(filename, mode = 'w') # rubocop:disable Lint/UselessAssignment:
+      file.close
     end
     false
   end
@@ -122,8 +123,8 @@ Type `help` for a list of available commands.')
   def do_write(arg)
     filename = arg.split(' ')[0]
     content = arg[filename.length + 1..-1]
-    f = File.open(filename, mode = 'w')
-    f.syswrite(content)
-    f.close
+    file = File.open(filename, mode = 'w') # rubocop:disable Lint/UselessAssignment:
+    file.syswrite(content)
+    file.close
   end
 end

--- a/lib/basic_shell.rb
+++ b/lib/basic_shell.rb
@@ -1,5 +1,7 @@
 require 'fileutils'
 
+require 'sys-proctable'
+
 require 'cmd'
 
 # A simple bash like shell made with rash/cmd.rb
@@ -133,5 +135,36 @@ Type `help` for a list of available commands.')
     # TODO: error handling (permission/non-such/non-such-dir)
     file.syswrite(content)
     file.close
+  end
+
+  def do_fork(arg)
+    r, w = IO.pipe
+    pid = Process.spawn(arg, out: w)
+    Process.detach pid
+    puts 'spawned process under pid: '+ pid.to_s
+    w.close
+    r.close
+    false
+  end
+
+  # Usage: kill SIGNAL [PID]...
+  #
+  # Send a system specific SIGNAL to the process(es) specified by the PID(s)
+  def do_kill(arg)
+    signal = arg.split(' ')[0]
+    pids = arg[signal.length+1..-1].split(' ')
+    pids.each do |pid|
+      Process.kill(signal, pid)
+      # TODO: error handling (non-such-signal/non-such-pid)
+    end
+    false
+  end
+
+  # Usage: ps
+  #
+  # Print all the currently running (and visible) processes within the system
+  def do_ps(arg)
+    puts Sys::ProcTable.ps
+    # TODO: format better
   end
 end

--- a/lib/basic_shell.rb
+++ b/lib/basic_shell.rb
@@ -76,7 +76,9 @@ Type `help` for a list of available commands.')
   def do_cat(arg)
     args = arg.split(' ')
     args.each do |file|
-      File.open(file).readlines.each(&method(:puts))
+      f = File.open(file)
+      f.readlines.each(&method(:puts))
+      f.close
     end
     false
   end
@@ -87,7 +89,7 @@ Type `help` for a list of available commands.')
   def do_touch(arg)
     args = arg.split(' ')
     args.each do |file|
-      File.open(file, mode = 'w') # rubocop:disable Lint/UselessAssignment:
+      File.open(file, mode = 'w').close # rubocop:disable Lint/UselessAssignment:
     end
     false
   end

--- a/lib/basic_shell.rb
+++ b/lib/basic_shell.rb
@@ -141,6 +141,8 @@ Type `help` for a list of available commands.')
   #
   # Fork and run the raw system COMMAND as a detached process.
   def do_fork(arg)
+    # TODO: it should really spawn a subshell of BasicShell and not go directly to system
+    # TODO: though im having difficulty thinking of a nice way to do that.
     r, w = IO.pipe
     pid = Process.spawn(arg, out: w)
     Process.detach pid

--- a/lib/basic_shell.rb
+++ b/lib/basic_shell.rb
@@ -30,7 +30,7 @@ Type `help` for a list of available commands.')
       puts Dir.entries(Dir.pwd)
     else
       puts Dir.entries(arg)
-      # TODO: error handling
+      # TODO: error handling (permission/non-such)
     end
   end
 
@@ -39,7 +39,7 @@ Type `help` for a list of available commands.')
   # Change the current working DIRECTORY.
   def do_cd(arg)
     Dir.chdir(arg)
-    # TODO: error handling
+    # TODO: error handling (permission/non-such)
     false
   end
 
@@ -48,6 +48,7 @@ Type `help` for a list of available commands.')
   # Create one or more DIRECTORIES.
   def do_mkdir(arg)
     FileUtils.mkdir arg.split(' ')
+    # TODO: error handling (permission/already exists)
     false
   end
 
@@ -56,6 +57,7 @@ Type `help` for a list of available commands.')
   # Removes one or more DIRECTORIES.
   def do_rmdir(arg)
     FileUtils.rmdir arg.split(' ')
+    # TODO: error handling (permission/non-such)
     false
   end
 
@@ -64,7 +66,7 @@ Type `help` for a list of available commands.')
   # Remove one or more FILE(s).
   def do_rm(arg)
     FileUtils.rm arg.split(' ')
-    # TODO: error handling
+    # TODO: error handling (permission/non-such)
     false
   end
 
@@ -74,7 +76,7 @@ Type `help` for a list of available commands.')
   def do_mv(arg)
     args = arg.split(' ')
     FileUtils.mv args[0], args[1]
-    # TODO: error handling
+    # TODO: error handling (permission/non-such/non-such-dir)
     false
   end
 
@@ -84,7 +86,7 @@ Type `help` for a list of available commands.')
   def do_cp(arg)
     args = arg.split(' ')
     FileUtils.cp args[0], args[1]
-    # TODO: error handling
+    # TODO: error handling (permission/non-such/non-such-dir)
     false
   end
 
@@ -95,6 +97,7 @@ Type `help` for a list of available commands.')
     args = arg.split(' ')
     args.each do |filename|
       file = File.open(filename)
+      # TODO: error handling (permission/non-such)
       file.readlines.each(&method(:puts))
       file.close
     end
@@ -110,6 +113,7 @@ Type `help` for a list of available commands.')
     args = arg.split(' ')
     args.each do |filename|
       file = File.open(filename, mode = 'w') # rubocop:disable Lint/UselessAssignment:
+      # TODO: error handling (permission/non-such/non-such-dir)
       file.close
     end
     false
@@ -124,6 +128,7 @@ Type `help` for a list of available commands.')
     filename = arg.split(' ')[0]
     content = arg[filename.length + 1..-1]
     file = File.open(filename, mode = 'w') # rubocop:disable Lint/UselessAssignment:
+    # TODO: error handling (permission/non-such/non-such-dir)
     file.syswrite(content)
     file.close
   end

--- a/lib/basic_shell.rb
+++ b/lib/basic_shell.rb
@@ -1,0 +1,96 @@
+require 'fileutils'
+
+require 'cmd'
+
+# A simple bash like shell made with rash/cmd.rb
+class BasicShell < Cmd
+  def initialize(prompt = 'rashbs> ',
+                 welcome = 'Welcome to the Ruby basic shell.
+Type `help` for a list of available commands.')
+    @prompt = prompt
+    @welcome = welcome
+
+    init_line_reader
+  end
+
+  # Print the current working DIRECTORY.
+  def do_pwd(arg)
+    puts Dir.pwd
+  end
+
+  # List the filenames within a DIRECTORY.
+  #
+  # If no DIRECTORY is specified the current working DIRECTORY will be listed.
+  def do_ls(arg)
+    if arg == ''
+      puts Dir.entries(Dir.pwd)
+    else
+      puts Dir.entries(arg)
+      # TODO: error handling
+    end
+  end
+
+  # Change the current working DIRECTORY.
+  def do_cd(arg)
+    Dir.chdir(arg)
+    # TODO: error handling
+    false
+  end
+
+  # Create one or more DIRECTORIES.
+  def do_mkdir(arg)
+    FileUtils.mkdir arg.split(' ')
+    false
+  end
+
+  # Removes one or more DIRECTORIES.
+  def do_rmdir(arg)
+    FileUtils.rmdir arg.split(' ')
+    false
+  end
+
+  # Remove one or more FILE(s).
+  def do_rm(arg)
+    FileUtils.rm arg.split(' ')
+    # TODO: error handling
+    false
+  end
+
+  # Move a FILE to the specified path.
+  def do_mv(arg)
+    args = arg.split(' ')
+    FileUtils.mv args[0], args[1]
+    # TODO: error handling
+    false
+  end
+
+  # Copy a FILE to the specified path.
+  def do_cp(arg)
+    args = arg.split(' ')
+    FileUtils.cp args[0], args[1]
+    # TODO: error handling
+    false
+  end
+
+  # Concatenate FILE(s) to standard output.
+  def do_cat(arg)
+    args = arg.split(' ')
+    args.each do |file|
+      File.open(file).readlines.each(&method(:puts))
+    end
+    false
+  end
+
+  # Update the access and modification times of each FILE to the current time.
+  #
+  # A FILE argument that does not exist is created empty.
+  def do_touch(arg)
+    args = arg.split(' ')
+    args.each do |file|
+      File.open(file, mode = 'w') # rubocop:disable Lint/UselessAssignment:
+    end
+    false
+  end
+
+  # TODO: need some method to write to files (maybe implement the > operator?)
+end

--- a/lib/cmd.rb
+++ b/lib/cmd.rb
@@ -89,13 +89,15 @@ Type `help` for a list of available commands.')
   # the +cmd_loop+.
 
   def help_help(arg)
-    puts('Print the available commands within this shell.')
-    puts('Use `help <command name>` to get help on a specific command')
+    puts('Usage: help [COMMAND]')
+    puts('')
+    puts('List the available commands within this shell.')
+    puts('If COMMAND is given get help on the specified command.')
   end
 
   def do_help(arg)
     if arg == '' # basic +help+ command
-      puts('Use `help <command_name>` to get help on a specific command')
+      puts('Use `help COMMAND` to get help on a specific command')
       puts('Below is a list of available commands:')
       method_commands = self.class.instance_methods(false).select { |s| s.to_s.start_with?('do_') }
       method_commands.each do |method_symbol|
@@ -114,11 +116,15 @@ Type `help` for a list of available commands.')
     false
   end
 
+  # Usage: exit
+  #
   # Exit the command shell.
   def do_exit(arg)
     true
   end
 
+  # Usage: history
+  #
   # Print the history of past issued commands.
   def do_history(arg)
     puts(Readline::HISTORY.to_a)

--- a/lib/cmd.rb
+++ b/lib/cmd.rb
@@ -159,7 +159,7 @@ Type `help` for a list of available commands.')
 
   # Clean a command method comment string to be more console readable.
   def clean_help_comment(raw_comment)
-    raw_comment.gsub!(/^# /, '')
+    raw_comment.gsub!(/(^# |^#)/, '')
     raw_comment.strip
   end
 end

--- a/lib/cmd.rb
+++ b/lib/cmd.rb
@@ -34,9 +34,10 @@ Type `help` for a list of available commands.')
       end
 
       pre_cmd(input)
-
-      if !(command_method = get_command_method_symbol(input.split(' ')[0])).nil?
-        break if send(command_method, input)
+      command_name = input.split(' ')[0]
+      command_args = input[input.split(' ')[0].length..-1].lstrip
+      if !(command_method = get_command_method_symbol(command_name)).nil?
+        break if send(command_method, command_args)
       elsif on_unknown_cmd(input)
         break
       end
@@ -87,13 +88,13 @@ Type `help` for a list of available commands.')
   # Note: If a +do_<command_name>+ command method returns +true+ it will terminate
   # the +cmd_loop+.
 
-  def help_help(input)
+  def help_help(arg)
     puts('Print the available commands within this shell.')
     puts('Use `help <command name>` to get help on a specific command')
   end
 
-  def do_help(input)
-    if input == 'help' # basic +help+ command
+  def do_help(arg)
+    if arg == '' # basic +help+ command
       puts('Use `help <command_name>` to get help on a specific command')
       puts('Below is a list of available commands:')
       method_commands = self.class.instance_methods(false).select { |s| s.to_s.start_with?('do_') }
@@ -101,9 +102,9 @@ Type `help` for a list of available commands.')
         puts(method_symbol.to_s[3..-1])
       end
     else # advanced +help <command_name>+ command
-      target_command = input[5..-1]
+      target_command = arg
       if !(target_command_help_method = get_command_help_method_symbol(target_command)).nil?
-        send(target_command_help_method, input)
+        send(target_command_help_method, arg)
       elsif !(target_command_method_help_comment = get_command_method_help_comment(target_command)).nil?
         puts(target_command_method_help_comment)
       else
@@ -114,12 +115,12 @@ Type `help` for a list of available commands.')
   end
 
   # Exit the command shell.
-  def do_exit(input)
+  def do_exit(arg)
     true
   end
 
   # Print the history of past issued commands.
-  def do_history(input)
+  def do_history(arg)
     puts(Readline::HISTORY.to_a)
   end
 

--- a/test/basic_shell_test.rb
+++ b/test/basic_shell_test.rb
@@ -60,4 +60,22 @@ class CmdTest < Test::Unit::TestCase
     end
     assert_true(output.to_s.include?(pwd))
   end
+
+  def test_cd_null
+    old_pwd = Dir.pwd
+    Readline.stubs(:readline)
+            .returns('cd  ', 'cd ', 'cd', 'exit')
+    @shell.cmd_loop
+    new_pwd = Dir.pwd
+    assert_equal(old_pwd, new_pwd)
+  end
+
+  def test_cd_pwd
+    old_pwd = Dir.pwd
+    Readline.stubs(:readline)
+        .returns('cd .', 'exit')
+    @shell.cmd_loop
+    new_pwd = Dir.pwd
+    assert_equal(old_pwd, new_pwd)
+  end
 end

--- a/test/basic_shell_test.rb
+++ b/test/basic_shell_test.rb
@@ -116,25 +116,16 @@ class BasicShellTest < Test::Unit::TestCase
     Dir.chdir(dir)
     assert_equal(dir, Dir.pwd)
     Readline.stubs(:readline)
-            .returns('touch testfile', 'exit')
+            .returns('touch test_file', 'exit')
     @shell.cmd_loop
-    assert_true(File.exist?('testfile'))
+    assert_true(File.exist?('test_file'))
     Dir.chdir(old_pwd)
     assert_equal(old_pwd, Dir.pwd)
     FileUtils.rm_rf dir
   end
 
-  def create_tempfile_test_file(name, content)
-    tempfile = Tempfile.new(name)
-    tfd = tempfile.open
-    tfd.write(content)
-    tfd.close
-    assert_true(File.exist?(tempfile.path.to_s))
-    tempfile
-  end
-
   def test_cat
-    tempfile = create_tempfile_test_file('testfile', 'test content')
+    tempfile = create_tempfile_test_file('test_file', 'test content')
     Readline.stubs(:readline)
             .returns('cat ' + tempfile.path.to_s, 'exit')
 
@@ -147,8 +138,8 @@ class BasicShellTest < Test::Unit::TestCase
   end
 
   def test_cat_multiple
-    tempfile1 = create_tempfile_test_file('testfile1', 'test content 1')
-    tempfile2 = create_tempfile_test_file('testfile2', 'test content 2')
+    tempfile1 = create_tempfile_test_file('test_file_1', 'test content 1')
+    tempfile2 = create_tempfile_test_file('test_file_2', 'test content 2')
 
     Readline.stubs(:readline)
             .returns('cat ' + tempfile1.path.to_s + ' ' + tempfile2.path.to_s, 'exit')
@@ -175,7 +166,7 @@ class BasicShellTest < Test::Unit::TestCase
   end
 
   def test_rm
-    tempfile = create_tempfile_test_file('testfile', 'test content')
+    tempfile = create_tempfile_test_file('test_file', 'test content')
     Readline.stubs(:readline)
             .returns('rm ' + tempfile.path.to_s, 'exit')
 
@@ -185,8 +176,8 @@ class BasicShellTest < Test::Unit::TestCase
   end
 
   def test_rm_multiple
-    tempfile1 = create_tempfile_test_file('testfile1', 'test content 1')
-    tempfile2 = create_tempfile_test_file('testfile2', 'test content 2')
+    tempfile1 = create_tempfile_test_file('test_file_1', 'test content 1')
+    tempfile2 = create_tempfile_test_file('test_file_2', 'test content 2')
 
     Readline.stubs(:readline)
             .returns('rm ' + tempfile1.path.to_s + ' ' + tempfile2.path.to_s, 'exit')

--- a/test/basic_shell_test.rb
+++ b/test/basic_shell_test.rb
@@ -93,6 +93,8 @@ class BasicShellTest < Test::Unit::TestCase
     @shell.cmd_loop
     new_pwd = Dir.pwd
     assert_not_equal(old_pwd, new_pwd)
+    Dir.chdir(old_pwd)
+    assert_equal(old_pwd, Dir.pwd)
     FileUtils.rm_rf dir
   end
 end

--- a/test/basic_shell_test.rb
+++ b/test/basic_shell_test.rb
@@ -74,7 +74,7 @@ class CmdTest < Test::Unit::TestCase
   def test_cd_pwd
     old_pwd = Dir.pwd
     Readline.stubs(:readline)
-        .returns('cd .', 'exit')
+            .returns('cd .', 'exit')
     @shell.cmd_loop
     new_pwd = Dir.pwd
     assert_equal(old_pwd, new_pwd)
@@ -82,7 +82,7 @@ class CmdTest < Test::Unit::TestCase
 
   def test_cd_dir
     old_pwd = Dir.pwd
-    dir = Dir.mktmpdir("rash_basic_shell_tests-")
+    dir = Dir.mktmpdir('rash_basic_shell_tests-')
     Readline.stubs(:readline)
             .returns('cd ' + dir, 'exit')
     @shell.cmd_loop

--- a/test/basic_shell_test.rb
+++ b/test/basic_shell_test.rb
@@ -189,8 +189,8 @@ class BasicShellTest < Test::Unit::TestCase
   end
 
   def test_mv
-    tempfile1 = create_tempfile_test_file('testfile1', 'test content 1')
-    tempfile2 = create_tempfile_test_file('testfile2', 'test content 2')
+    tempfile1 = create_tempfile_test_file('test_file_1', 'test content 1')
+    tempfile2 = create_tempfile_test_file('test_file_2', 'test content 2')
 
     Readline.stubs(:readline)
             .returns('mv ' + tempfile1.path.to_s + ' ' + tempfile2.path.to_s, 'exit')
@@ -203,8 +203,8 @@ class BasicShellTest < Test::Unit::TestCase
   end
 
   def test_cp
-    tempfile1 = create_tempfile_test_file('testfile1', 'test content 1')
-    tempfile2 = create_tempfile_test_file('testfile2', 'test content 2')
+    tempfile1 = create_tempfile_test_file('test_file_1', 'test content 1')
+    tempfile2 = create_tempfile_test_file('test_file_2', 'test content 2')
 
     Readline.stubs(:readline)
             .returns('cp ' + tempfile1.path.to_s + ' ' + tempfile2.path.to_s, 'exit')

--- a/test/basic_shell_test.rb
+++ b/test/basic_shell_test.rb
@@ -1,0 +1,63 @@
+require_relative 'helper'
+
+class CmdTest < Test::Unit::TestCase
+  def setup
+    @shell = BasicShell.new
+  end
+
+  def teardown
+    # Do nothing
+  end
+
+  def test_initialization
+    assert_true(@shell.is_a?(Cmd))
+    assert_true(@shell.is_a?(BasicShell))
+  end
+
+  def test_exit
+    Readline.expects(:readline)
+            .returns('exit')
+    @shell.cmd_loop
+  end
+
+  def test_smoke_help
+    Readline.stubs(:readline)
+            .returns('help', 'exit')
+    @shell.cmd_loop
+  end
+
+  def test_smoke_help_methods
+    Readline.stubs(:readline)
+            .returns('help help', 'help history', 'help exit', 'exit')
+    @shell.cmd_loop
+  end
+
+  def test_smoke_help_nonsuch
+    Readline.stubs(:readline)
+            .returns('help nonsuch', 'exit')
+    @shell.cmd_loop
+  end
+
+  def test_smoke_history
+    Readline.stubs(:readline)
+            .returns('foo', 'foo', 'foo', 'history', 'exit')
+    @shell.cmd_loop
+  end
+
+  def test_smoke_history_blank
+    Readline.stubs(:readline)
+            .returns('', '  ', '   ', 'history', 'exit')
+    @shell.cmd_loop
+  end
+
+  def test_pwd
+    pwd = Dir.pwd
+    Readline.stubs(:readline)
+            .returns('pwd', 'exit')
+
+    output = capture_output do
+      @shell.cmd_loop
+    end
+    assert_true(output.to_s.include?(pwd))
+  end
+end

--- a/test/basic_shell_test.rb
+++ b/test/basic_shell_test.rb
@@ -196,4 +196,32 @@ class BasicShellTest < Test::Unit::TestCase
     assert_false(File.exist?(tempfile1.path.to_s))
     assert_false(File.exist?(tempfile2.path.to_s))
   end
+
+  def test_mv
+    tempfile1 = create_tempfile_test_file('testfile1', 'test content 1')
+    tempfile2 = create_tempfile_test_file('testfile2', 'test content 2')
+
+    Readline.stubs(:readline)
+            .returns('mv ' + tempfile1.path.to_s + ' ' + tempfile2.path.to_s, 'exit')
+
+    @shell.cmd_loop
+
+    assert_false(File.exist?(tempfile1.path.to_s))
+    assert_true(File.exist?(tempfile2.path.to_s))
+    assert_equal(File.open(tempfile2.path.to_s).read, 'test content 1')
+  end
+
+  def test_cp
+    tempfile1 = create_tempfile_test_file('testfile1', 'test content 1')
+    tempfile2 = create_tempfile_test_file('testfile2', 'test content 2')
+
+    Readline.stubs(:readline)
+            .returns('cp ' + tempfile1.path.to_s + ' ' + tempfile2.path.to_s, 'exit')
+
+    @shell.cmd_loop
+
+    assert_true(File.exist?(tempfile1.path.to_s))
+    assert_true(File.exist?(tempfile2.path.to_s))
+    assert_equal(File.open(tempfile2.path.to_s).read, 'test content 1')
+  end
 end

--- a/test/basic_shell_test.rb
+++ b/test/basic_shell_test.rb
@@ -1,7 +1,7 @@
 require_relative 'helper'
 require 'tmpdir'
 
-class CmdTest < Test::Unit::TestCase
+class BasicShellTest < Test::Unit::TestCase
   def setup
     @shell = BasicShell.new
   end

--- a/test/basic_shell_test.rb
+++ b/test/basic_shell_test.rb
@@ -1,4 +1,5 @@
 require_relative 'helper'
+require 'tmpdir'
 
 class CmdTest < Test::Unit::TestCase
   def setup
@@ -77,5 +78,16 @@ class CmdTest < Test::Unit::TestCase
     @shell.cmd_loop
     new_pwd = Dir.pwd
     assert_equal(old_pwd, new_pwd)
+  end
+
+  def test_cd_dir
+    old_pwd = Dir.pwd
+    dir = Dir.mktmpdir("rash_basic_shell_tests-")
+    Readline.stubs(:readline)
+            .returns('cd ' + dir, 'exit')
+    @shell.cmd_loop
+    new_pwd = Dir.pwd
+    assert_not_equal(old_pwd, new_pwd)
+    FileUtils.rm_rf dir
   end
 end

--- a/test/basic_shell_test.rb
+++ b/test/basic_shell_test.rb
@@ -15,6 +15,9 @@ class BasicShellTest < Test::Unit::TestCase
     assert_true(@shell.is_a?(BasicShell))
   end
 
+  # Smokes that ensure functionality from Cmd is maintained
+  # TODO: is there a better way to test this with inheritance?
+
   def test_exit
     Readline.expects(:readline)
             .returns('exit')
@@ -50,6 +53,8 @@ class BasicShellTest < Test::Unit::TestCase
             .returns('', '  ', '   ', 'history', 'exit')
     @shell.cmd_loop
   end
+
+  # new functionality within BasicShell
 
   def test_pwd
     pwd = Dir.pwd

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,6 +8,17 @@ if ENV['CI'] == 'true'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 
+require 'tempfile'
+
+def create_tempfile_test_file(name, content)
+  tempfile = Tempfile.new(name)
+  tfd = tempfile.open
+  tfd.write(content)
+  tfd.close
+  assert_true(File.exist?(tempfile.path.to_s))
+  tempfile
+end
+
 require 'test/unit'
 require 'mocha/test_unit'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,3 +12,4 @@ require 'test/unit'
 require 'mocha/test_unit'
 
 require 'cmd'
+require 'basic_shell'


### PR DESCRIPTION
A basic shell that implements some common filesystem and process commands.

**Note:** `cmd.rb/Cmd` was modified to automatically parse out the command prefix for defined `do_<command_name>` commands. Now only the subsequent content after the command name will be given as a `arg` parameter in `do_<command_name>` methods. This removes the need for filtering the basic command prefix.

This does not include proper error handling currently. If something goes wrong a standard Ruby traceback will be given.

resolves #7 
resolves #8 